### PR TITLE
[#3] Remove the line to copy sqlite in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ FROM gcr.io/distroless/base-debian12
 
 COPY --from=ui-build /app/ui/dist /app/ui/dist
 COPY --from=server-build /go/src/app/rush /app
-# TODO: Remove it after migrating to MongoDB.
-COPY sqlite /app/sqlite
 
 WORKDIR /app
 


### PR DESCRIPTION
Now, the database is migrated into MongoDB. It doesn't need to copy the sqlite files into docker image anymore.
It removes the line to copy them into the image.