### PR TITLE
[#19] Fix imports in UI to fix an error related to material UI

### DIFF
--- a/ui/src/Layout.tsx
+++ b/ui/src/Layout.tsx
@@ -1,6 +1,5 @@
 import { Outlet } from 'react-router-dom';
-import Box from '@mui/material/Box';
-import Container from '@mui/material/Container';
+import { Box, Container } from '@mui/material';
 import Sidebar, { SIDEBAR_WIDTH } from './Sidebar';
 
 export const HEADER_HEIGHT = 64;

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -1,9 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom';
 import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
 import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
-import Box from '@mui/material/Box';
-import ListItemButton from '@mui/material/ListItemButton';
-import Stack from '@mui/material/Stack';
+import { Box, ListItemButton, Stack } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import Logo from './assets/logo.svg';
 


### PR DESCRIPTION
```
chunk-HJRYGX47.js?v=ff44cbe1:33 Uncaught TypeError: createTheme_default is not a function
at chunk-HJRYGX47.js?v=ff44cbe1:33:20
```
there was this error related to Material UI.
This PR fixes
```ts
import Box from "@mui/material/Box";
```
to be
```ts
import {Box} from "@mui/material";
```

closes #19 