### PR TITLE
[#12] Add a bottom navigation bar for mobile

### DIFF
--- a/ui/src/BottomNavigation.tsx
+++ b/ui/src/BottomNavigation.tsx
@@ -1,0 +1,45 @@
+import { NavLink } from 'react-router-dom';
+import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import { Box, ListItemButton, Stack } from '@mui/material';
+
+export const BOTTOM_NAV_HEIGHT = 56;
+
+const BottomNavigation = () => (
+  <Box
+    sx={{
+      position: 'fixed',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: BOTTOM_NAV_HEIGHT,
+      bgcolor: 'background.paper',
+      borderTop: (theme) => `solid 1px ${theme.palette.divider}`,
+      display: 'flex',
+      justifyContent: 'space-around',
+      alignItems: 'center',
+      px: 2,
+    }}
+  >
+    <NavigationItem title="Sessions" path="/sessions" icon={<AssessmentOutlinedIcon />} />
+    <NavigationItem title="Users" path="/users" icon={<AssessmentOutlinedIcon />} />
+  </Box>
+);
+
+const NavigationItem = ({ title, path, icon }: { title: string; path: string; icon: JSX.Element }) => (
+  <ListItemButton
+    component={NavLink}
+    to={path}
+    sx={{
+      flexDirection: 'column',
+      alignItems: 'center',
+      '&.active': {
+        color: 'primary.main',
+      },
+    }}
+  >
+    <Stack sx={{ width: 24, height: 24, mb: 0.5 }}>{icon}</Stack>
+    <Box sx={{ fontSize: '0.75rem' }}>{title}</Box>
+  </ListItemButton>
+);
+
+export default BottomNavigation;

--- a/ui/src/Layout.tsx
+++ b/ui/src/Layout.tsx
@@ -1,36 +1,38 @@
+// Layout.tsx
 import { Outlet } from 'react-router-dom';
-import { Box, Container } from '@mui/material';
+import { Box, Container, useMediaQuery, useTheme } from '@mui/material';
+import BottomNavigation, { BOTTOM_NAV_HEIGHT } from './BottomNavigation';
 import Sidebar, { SIDEBAR_WIDTH } from './Sidebar';
 
 export const HEADER_HEIGHT = 64;
 
-const Layout = () => (
-  <>
-    {/* <AppBar
-        sx={{
-          width: `calc(100% - ${SIDEBAR_WIDTH}px)`,
-          height: HEADER_HEIGHT,
-          boxShadow: 'none',
-          bgcolor: 'transparent',
-        }}
-      /> */}
+const Layout = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-    <Box sx={{ display: 'flex', minHeight: '100%' }}>
-      <Box sx={{ width: SIDEBAR_WIDTH }}>
-        <Sidebar />
-      </Box>
+  return (
+    <Box sx={{ display: 'flex', flexDirection: isMobile ? 'column' : 'row', minHeight: '100vh' }}>
+      {!isMobile && (
+        <Box sx={{ width: SIDEBAR_WIDTH }}>
+          <Sidebar />
+        </Box>
+      )}
 
       <Container
         sx={{
-          py: `${HEADER_HEIGHT + 16}px`,
+          py: isMobile ? `16px` : `${HEADER_HEIGHT + 16}px`,
+          pb: isMobile ? `${BOTTOM_NAV_HEIGHT + 16}px` : '16px',
           boxSizing: 'border-box',
-          width: `calc(100% - ${SIDEBAR_WIDTH}px)`,
+          width: isMobile ? '100%' : `calc(100% - ${SIDEBAR_WIDTH}px)`,
+          flexGrow: 1,
         }}
       >
         <Outlet />
       </Container>
+
+      {isMobile && <BottomNavigation />}
     </Box>
-  </>
-);
+  );
+};
 
 export default Layout;

--- a/ui/src/UserList.tsx
+++ b/ui/src/UserList.tsx
@@ -70,7 +70,7 @@ const UserList = () => {
           </TableHead>
           <TableBody>
             {users.map((user) => (
-              <TableRow key={user.name}>
+              <TableRow key={user.id}>
                 <TableCell>{user.name}</TableCell>
                 <TableCell>{user.generation}</TableCell>
                 <TableCell>{user.isActive ? 'Yes' : 'No'}</TableCell>


### PR DESCRIPTION
Sidebar takes up a big space, it's hard for users to see the pages.
This PR introduces a bottom navigation bar, which has the same role as the side bar.
Before:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/e7f517db-4164-475c-b543-3f2132eac1d0">

After:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/5e1a574c-5860-4178-acb5-6c908aa2c2c0">