### PR TITLE
[#27] Add a loader and update navigation icons

### DIFF
--- a/ui/src/AttendanceList.tsx
+++ b/ui/src/AttendanceList.tsx
@@ -11,6 +11,8 @@ import {
   Container,
   Typography,
   TablePagination,
+  CircularProgress,
+  Box,
 } from '@mui/material';
 import { Attendance, getAttendances } from './client/http';
 
@@ -42,7 +44,9 @@ const AttendanceList: React.FC = () => {
         <Typography variant="h4" sx={{ mb: 5 }}>
           Attendance List
         </Typography>
-        <Typography>Loading...</Typography>
+        <Box display="flex" justifyContent="center" alignItems="center">
+          <CircularProgress />
+        </Box>
       </Container>
     );
   }

--- a/ui/src/BottomNavigation.tsx
+++ b/ui/src/BottomNavigation.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import { GroupOutlined, RunCircleOutlined } from '@mui/icons-material';
 import { Box, ListItemButton, Stack } from '@mui/material';
 
 export const BOTTOM_NAV_HEIGHT = 56;
@@ -20,8 +20,8 @@ const BottomNavigation = () => (
       px: 2,
     }}
   >
-    <NavigationItem title="Sessions" path="/sessions" icon={<AssessmentOutlinedIcon />} />
-    <NavigationItem title="Users" path="/users" icon={<AssessmentOutlinedIcon />} />
+    <NavigationItem title="Sessions" path="/sessions" icon={<RunCircleOutlined />} />
+    <NavigationItem title="Users" path="/users" icon={<GroupOutlined />} />
   </Box>
 );
 

--- a/ui/src/SessionDetail.tsx
+++ b/ui/src/SessionDetail.tsx
@@ -55,7 +55,9 @@ const SessionDetail = () => {
         <Typography variant="h4" sx={{ mb: 3 }}>
           Session Detail
         </Typography>
-        <Typography>Loading...</Typography>
+        <Box display="flex" justifyContent="center" alignItems="center">
+          <CircularProgress />
+        </Box>
       </Container>
     );
   }

--- a/ui/src/SessionList.tsx
+++ b/ui/src/SessionList.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Box,
   Modal,
+  CircularProgress,
 } from '@mui/material';
 import SessionCreate from './SessionCreate';
 import { Session, getSessions } from './client/http';
@@ -47,7 +48,9 @@ const SessionList: React.FC = () => {
         <Typography variant="h4" sx={{ mb: 5 }}>
           Sessions
         </Typography>
-        <Typography>Loading...</Typography>
+        <Box display="flex" justifyContent="center" alignItems="center">
+          <CircularProgress />
+        </Box>
       </Container>
     );
   }

--- a/ui/src/Sidebar.tsx
+++ b/ui/src/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom';
-import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import { GroupOutlined, RunCircleOutlined } from '@mui/icons-material';
 import ExpandMoreRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
 import { Box, ListItemButton, Stack } from '@mui/material';
 import { alpha } from '@mui/material/styles';
@@ -36,8 +36,8 @@ const Sidebar = () => {
       </Box>
 
       <Stack>
-        <Navigation title="Sessions" path="/sessions" icon={<AssessmentOutlinedIcon />} />
-        <Navigation title="Users" path="/users" icon={<AssessmentOutlinedIcon />} />
+        <Navigation title="Sessions" path="/sessions" icon={<RunCircleOutlined />} />
+        <Navigation title="Users" path="/users" icon={<GroupOutlined />} />
       </Stack>
     </Stack>
   );

--- a/ui/src/UserList.tsx
+++ b/ui/src/UserList.tsx
@@ -10,6 +10,8 @@ import {
   Container,
   Typography,
   TablePagination,
+  Box,
+  CircularProgress,
 } from '@mui/material';
 import { User, getUsers } from './client/http';
 
@@ -49,7 +51,9 @@ const UserList = () => {
         <Typography variant="h4" sx={{ mb: 5 }}>
           Users
         </Typography>
-        <Typography>Loading...</Typography>
+        <Box display="flex" justifyContent="center" alignItems="center">
+          <CircularProgress />
+        </Box>
       </Container>
     );
   }


### PR DESCRIPTION
Random icons were used for navigation bar, and a plain text was showing when loading data.
This PR fixes them.

icons:
<img width="314" alt="image" src="https://github.com/user-attachments/assets/fa376b0f-73e3-43a0-bb79-5cacc4f9a717">

loader:
circular progress of mui

#27 