### PR TITLE
[#25] Fix generation to be float

### DIFF
--- a/http/router.go
+++ b/http/router.go
@@ -13,11 +13,11 @@ import (
 )
 
 type UsersPostRequest struct {
-	Name       string `json:"name"`
-	University string `json:"university"`
-	Phone      string `json:"phone"`
-	Generation string `json:"generation"`
-	IsActive   bool   `json:"is_active"`
+	Name       string  `json:"name"`
+	University string  `json:"university"`
+	Phone      string  `json:"phone"`
+	Generation float64 `json:"generation"`
+	IsActive   bool    `json:"is_active"`
 }
 
 type SessionsPostRequest struct {

--- a/server/server.go
+++ b/server/server.go
@@ -9,12 +9,12 @@ import (
 )
 
 type User struct {
-	Id         string `json:"id"`
-	Name       string `json:"name"`
-	University string `json:"university"`
-	Phone      string `json:"phone"`
-	Generation string `json:"generation"`
-	IsActive   bool   `json:"is_active"`
+	Id         string  `json:"id"`
+	Name       string  `json:"name"`
+	University string  `json:"university"`
+	Phone      string  `json:"phone"`
+	Generation float64 `json:"generation"`
+	IsActive   bool    `json:"is_active"`
 }
 
 type Session struct {
@@ -117,7 +117,7 @@ func (s *Server) ListUsers(offset int, pageSize int) (*ListUsersResult, error) {
 	}, nil
 }
 
-func (s *Server) AddUser(name string, university string, phone string, generation string, isActive bool) error {
+func (s *Server) AddUser(name string, university string, phone string, generation float64, isActive bool) error {
 	return s.userRepo.Add(&user.User{
 		Name:       name,
 		University: university,

--- a/ui/src/client/http.ts
+++ b/ui/src/client/http.ts
@@ -17,7 +17,7 @@ const UserSchema = z
     name: z.string(),
     university: z.string(),
     phone: z.string(),
-    generation: z.string(),
+    generation: z.number(),
     is_active: z.boolean(),
   })
   .transform((data) => ({

--- a/user/repo.go
+++ b/user/repo.go
@@ -16,7 +16,7 @@ type mongodbUser struct {
 	Name       string             `bson:"name"`
 	University string             `bson:"university"`
 	Phone      string             `bson:"phone"`
-	Generation string             `bson:"generation"`
+	Generation float64            `bson:"generation"`
 	IsActive   bool               `bson:"is_active"`
 }
 

--- a/user/user.go
+++ b/user/user.go
@@ -1,10 +1,10 @@
 package user
 
 type User struct {
-	Id         string `json:"id"`
-	Name       string `json:"name"`
-	University string `json:"university"`
-	Phone      string `json:"phone"`
-	Generation string `json:"generation"`
-	IsActive   bool   `json:"is_active"`
+	Id         string  `json:"id"`
+	Name       string  `json:"name"`
+	University string  `json:"university"`
+	Phone      string  `json:"phone"`
+	Generation float64 `json:"generation"`
+	IsActive   bool    `json:"is_active"`
 }


### PR DESCRIPTION
#25 
User generation is stored as string that it's not sorted well.
For example, 1.0 would come after 10.0 and this is not what we want.
There are many ways to handle this issue, such as saving it in the format of `xxx.x`, etc.
However, for simplicity, this PR fixes the data type to be number.