### PR TITLE
[#34] Sort user option in the session form

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ import (
 	"rush/attendance"
 	"rush/session"
 	"rush/user"
+	"sort"
 	"time"
 )
 
@@ -153,6 +154,13 @@ func (s *Server) CreateSessionForm(sessionId string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to get users: %w", err)
 	}
+
+	sort.Slice(users, func(i, j int) bool {
+		if users[i].Generation != users[j].Generation {
+			return users[i].Generation > users[j].Generation
+		}
+		return users[i].Name < users[j].Name
+	})
 
 	dbSession, err := s.sessionRepo.Get(sessionId)
 	if err != nil {


### PR DESCRIPTION
When making options for the session forms, the options should be sorted.
This PR
- sorts the option in the descending order of user generation and ascending order of user name.

closes #34 