### PR TITLE
[#7|#37] Use a common date format for session create API and formats the date in UI to be more easily readable

### DIFF
--- a/http/router.go
+++ b/http/router.go
@@ -21,18 +21,10 @@ type UsersPostRequest struct {
 }
 
 type SessionsPostRequest struct {
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	StartsAt    *customTime `json:"starts_at"`
-	Score       int         `json:"score"`
-}
-
-type customTime struct {
-	Year  int `json:"year"`
-	Month int `json:"month"`
-	Day   int `json:"day"`
-	Hour  int `json:"hour"`
-	Min   int `json:"min"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	StartsAt    time.Time `json:"starts_at"`
+	Score       int       `json:"score"`
 }
 
 func SetUpRouter(router *gin.Engine, server *server.Server) {
@@ -115,12 +107,7 @@ func SetUpRouter(router *gin.Engine, server *server.Server) {
 				return
 			}
 
-			id, err := server.AddSession(
-				req.Name,
-				req.Description,
-				time.Date(req.StartsAt.Year, time.Month(req.StartsAt.Month), req.StartsAt.Day, req.StartsAt.Hour, req.StartsAt.Min, 0 /* =sec */, 0 /* =nsec */, time.UTC),
-				req.Score,
-			)
+			id, err := server.AddSession(req.Name, req.Description, req.StartsAt, req.Score)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return

--- a/ui/src/SessionCreate.tsx
+++ b/ui/src/SessionCreate.tsx
@@ -7,7 +7,7 @@ const SessionCreate = () => {
   const navigate = useNavigate();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [startsAt, setStartsAt] = useState(new Date());
+  const { dateInputValue, onDateInputValueChange, date: startsAt } = useDateTimeLocalInput();
   const [score, setScore] = useState(0);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -45,8 +45,8 @@ const SessionCreate = () => {
         <Input
           type="datetime-local"
           name="startsAt"
-          value={startsAt.toISOString().slice(0, 16)}
-          onChange={(e) => setStartsAt(new Date(e.target.value))}
+          value={dateInputValue}
+          onChange={(e) => onDateInputValueChange(e.target.value)}
           fullWidth
           sx={{ mb: 2 }}
         />
@@ -66,6 +66,32 @@ const SessionCreate = () => {
       </form>
     </Container>
   );
+};
+
+const useDateTimeLocalInput = (initialDate = new Date()) => {
+  const [date, setDate] = useState(initialDate);
+
+  const formatDateToInput = (newDate: Date) => {
+    const pad = (number: number) => number.toString().padStart(2, '0');
+
+    const year = newDate.getFullYear();
+    const month = pad(newDate.getMonth() + 1);
+    const day = pad(newDate.getDate());
+    const hours = pad(newDate.getHours());
+    const minutes = pad(newDate.getMinutes());
+
+    return `${year}-${month}-${day}T${hours}:${minutes}`;
+  };
+
+  const handleChange = (newInputValue: string) => {
+    setDate(new Date(newInputValue));
+  };
+
+  return {
+    dateInputValue: formatDateToInput(date),
+    onDateInputValueChange: handleChange,
+    date,
+  };
 };
 
 export default SessionCreate;

--- a/ui/src/SessionDetail.tsx
+++ b/ui/src/SessionDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { Container, Typography, Paper, Box, Button, CircularProgress } from '@mui/material';
 import QRCode from 'qrcode.react';
 import { Session, createSessionForm, getSession } from './client/http';
+import toYYYY년MM월DD일HH시MM분 from './common/date';
 
 const SessionDetail = () => {
   const navigate = useNavigate();
@@ -82,9 +83,9 @@ const SessionDetail = () => {
         <Typography variant="h6">Details</Typography>
         <Typography>Name: {session.name}</Typography>
         <Typography>Description: {session.description}</Typography>
-        <Typography>Start Time: {session.startsAt.toISOString()}</Typography>
+        <Typography>Starts At: {toYYYY년MM월DD일HH시MM분(session.startsAt)}</Typography>
         <Typography>Score: {session.score}</Typography>
-        <Typography>Created At: {session.createdAt.toISOString()}</Typography>
+        <Typography>Created At: {toYYYY년MM월DD일HH시MM분(session.createdAt)}</Typography>
       </Paper>
 
       <Paper sx={{ p: 2, mb: 3 }}>

--- a/ui/src/SessionList.tsx
+++ b/ui/src/SessionList.tsx
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import SessionCreate from './SessionCreate';
 import { Session, getSessions } from './client/http';
+import toYYYY년MM월DD일HH시MM분 from './common/date';
 
 const SessionList: React.FC = () => {
   const navigate = useNavigate();
@@ -92,18 +93,16 @@ const SessionList: React.FC = () => {
               <TableHead>
                 <TableRow>
                   <TableCell>Name</TableCell>
-                  <TableCell>Start Time</TableCell>
+                  <TableCell>Starts At</TableCell>
                   <TableCell>Score</TableCell>
-                  <TableCell>Created At</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
                 {paginatedSessions.map((session) => (
                   <TableRow key={session.id} onClick={() => handleRowClick(session)} style={{ cursor: 'pointer' }}>
                     <TableCell>{session.name}</TableCell>
-                    <TableCell>{session.startsAt.toISOString()}</TableCell>
+                    <TableCell>{toYYYY년MM월DD일HH시MM분(session.startsAt)}</TableCell>
                     <TableCell>{session.score}</TableCell>
-                    <TableCell>{session.createdAt.toISOString()}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/ui/src/client/http.ts
+++ b/ui/src/client/http.ts
@@ -132,16 +132,11 @@ export const createSession = async (
   startsAt: Date,
   score: number,
 ): Promise<Session> => {
+  console.log(startsAt.getHours(), startsAt.getMinutes());
   const response = await client.post('/sessions', {
     name,
     description,
-    starts_at: {
-      year: startsAt.getFullYear(),
-      month: startsAt.getMonth() + 1,
-      day: startsAt.getDate(),
-      hour: startsAt.getHours(),
-      minute: startsAt.getMinutes(),
-    },
+    starts_at: startsAt.toISOString(),
     score,
   });
   return response.data.id;

--- a/ui/src/common/date.ts
+++ b/ui/src/common/date.ts
@@ -1,0 +1,4 @@
+const toYYYY년MM월DD일HH시MM분 = (date: Date) =>
+  `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 ${date.getHours()}시 ${date.getMinutes()}분`;
+
+export default toYYYY년MM월DD일HH시MM분;


### PR DESCRIPTION
The session create modal's date was not functioning correctly. First, the http Post body's field name was wrong, but also KST was passed as UTC but without the zone info.
ex) 2000 Jan 1st 1pm KST -> 2000 Jan 1st 1pm UTC
Plus, the date data was formatted in `2024-07-30T10:50:00.000Z` format that it's so hard for users to read it.

This PR
- Fixes the `/api/sessions` POST request body to pass the time data with time zone
- Fixes the create modal to parse and format the date correctly that it shows/passes the correct date data
- Fixes the date data in UI to be more easily readable, which is `2024년 7월 30일 19시 50분` format.

closes #7 
closes #37 