### PR TITLE
[#53] Add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
+<!-- ex) [#1] Add GitHub pull request template -->
+
+## Background <!-- Required -->
+
+<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
+
+- Issue: #
+
+<!-- If this PR resolves any issues, please mention them. -->
+<!-- E.g., Resolves #000 -->
+
+## Changes <!-- Required -->
+
+<!-- Describe what changes or additions have been made in this PR. -->
+<!-- If there are any UI changes, please include screenshots to demonstrate them. -->
+
+-
+
+## Considerations <!-- Optional -->
+
+<!-- List any points that can not be described through code, -->
+<!-- or the reason why a certain way has been chosen among other ways -->
+<!-- Include them only when they are necessary, and not obvious. -->
+<!-- Do not abuse this section. Represent through the code as much as possible. -->
+
+## Remaining Tasks <!-- Optional -->
+
+<!-- Tasks to be completed after this PR. -->


### PR DESCRIPTION
resolves #53 

although there are many things to note in the PR description, it's hard to come up with the list.
The PR template will help developers not waste time thinking about that.
And it can normalize the PR description format that it's easier to review PRs.

this PR
- adds a PR template.