### PR TITLE
[#42] Add attendance GET API and save session/user name to attendance collection together

### DIFF
--- a/attendance/attendance.go
+++ b/attendance/attendance.go
@@ -7,8 +7,12 @@ type Attendance struct {
 	Id string `json:"id"`
 	// The unique identifier for the session that the user joined. E.g. "1"
 	SessionId string
+	// The name of the session that the user joined. E.g. "Yonsei University track"
+	SessionName string
 	// The unique identifier for the user. E.g. "1"
 	UserId string
+	// The name of the user. E.g. "Alice"
+	UserName string
 	// The time when the user joined the session.
 	JoinedAt time.Time `json:"joined_at"`
 	// The time when the attendance record was created.

--- a/attendance/form.go
+++ b/attendance/form.go
@@ -21,7 +21,7 @@ type Form struct {
 }
 
 type FormSubmission struct {
-	UserID         string
+	UserExternalId string
 	SubmissionTime time.Time
 }
 
@@ -137,7 +137,7 @@ func (f *formHandler) GetSubmissions(formId string) ([]FormSubmission, error) {
 
 	var submissions []FormSubmission
 	for externalId, submissionTime := range userExternalIdSubmissionTimeMap {
-		submissions = append(submissions, FormSubmission{UserID: externalId, SubmissionTime: submissionTime})
+		submissions = append(submissions, FormSubmission{UserExternalId: externalId, SubmissionTime: submissionTime})
 	}
 
 	return submissions, nil

--- a/http/handler.go
+++ b/http/handler.go
@@ -256,3 +256,22 @@ func handleApplyAttendance(server *server.Server) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"message": "Session closed successfully"})
 	}
 }
+
+func handleGetAttendanceForUser(server *server.Server) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		userId := c.Query("userId")
+		if userId == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "userId is required"})
+			return
+		}
+
+		attendances, err := server.GetAttendanceByUserId(userId)
+		if err != nil {
+			log.Printf("Error getting attendance for user: %+v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"attendances": attendances})
+	}
+}

--- a/http/router.go
+++ b/http/router.go
@@ -27,6 +27,7 @@ func SetUpRouter(router *gin.Engine, server *server.Server) {
 			protected.POST("/sessions", handleAddSession(server))
 			protected.POST("/sessions/:id/attendance-form", handleCreateSessionForm(server))
 			protected.POST("/sessions/:id/attendance", handleApplyAttendance(server))
+			protected.POST("/attendances", handleGetAttendanceForUser(server))
 		}
 	}
 


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->

- Issue: #42 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Fixes the attendance colleciton to have session, user names too so that they can be easily shown without fetching user, session docs again. user name wouldn't change easily and session name doesn't change after it closes most times.
- Adds attendance GET API.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
