### PR TITLE
[#98] Trim second for session start date and shows KST in session form

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,6 +73,7 @@ func main() {
 		rushUser.NewMongoDbRepo(userCollection), session.NewMongoDbRepo(sessionCollection),
 		attendance.NewFormHandler(formsService, driveService),
 		attendance.NewMongoDbRepo(attendanceCollection, clock),
+		must.OK1(time.LoadLocation("Asia/Seoul")),
 	)
 
 	router := gin.Default()

--- a/server/server.go
+++ b/server/server.go
@@ -93,10 +93,11 @@ type Server struct {
 	sessionRepo           sessionRepo
 	attendanceFormHandler attendanceFormHandler
 	attendanceRepo        attendanceRepo
+	formTimeLocation      *time.Location
 }
 
 func New(tokenInspector tokenInspector, authHandler authHandler, userRepo userRepo, sessionRepo sessionRepo,
-	attendanceFormHandler attendanceFormHandler, attendanceRepo attendanceRepo) *Server {
+	attendanceFormHandler attendanceFormHandler, attendanceRepo attendanceRepo, formTimeLocation *time.Location) *Server {
 	return &Server{
 		tokenInspector:        tokenInspector,
 		authHandler:           authHandler,
@@ -104,6 +105,7 @@ func New(tokenInspector tokenInspector, authHandler authHandler, userRepo userRe
 		sessionRepo:           sessionRepo,
 		attendanceFormHandler: attendanceFormHandler,
 		attendanceRepo:        attendanceRepo,
+		formTimeLocation:      formTimeLocation,
 	}
 }
 
@@ -275,7 +277,7 @@ func (s *Server) CreateSessionForm(sessionId string) (string, error) {
 	}
 
 	formTitle := fmt.Sprintf("[출석] %s", dbSession.Name)
-	startsAt := dbSession.StartsAt
+	startsAt := dbSession.StartsAt.In(s.formTimeLocation)
 	expiresAt := startsAt.Add(-time.Second)
 	formDescription := fmt.Sprintf(`%s을(를) 위한 출석용 구글폼입니다.
 폼 마감 시각은 %s입니다. %s 이후 요청은 무시됩니다.`, dbSession.Name, expiresAt.Format("2006-01-02 15:04:05"), startsAt.Format("2006-01-02 15:04:05"))

--- a/ui/src/SessionCreate.tsx
+++ b/ui/src/SessionCreate.tsx
@@ -30,6 +30,12 @@ const SessionCreate = () => {
     }
   };
 
+  const handleDateTimeChange = (newValue: dayjs.Dayjs | null) => {
+    if (newValue === null) return;
+    // Truncate seconds and milliseconds because sessions are created in minute precision.
+    setStartsAt(newValue.startOf('minute'));
+  };
+
   return (
     <Container>
       <Typography variant="h4" sx={{ mb: 3 }}>
@@ -55,9 +61,7 @@ const SessionCreate = () => {
         <DateTimePicker
           label="Starts At"
           value={startsAt}
-          onChange={(newValue) => {
-            setStartsAt(newValue ?? dayjs());
-          }}
+          onChange={handleDateTimeChange}
           minutesStep={10}
           shouldDisableDate={(date) => date.isBefore(dayjs(), 'day')}
           views={['year', 'month', 'day', 'hours', 'minutes']}


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
Session starting time was supposed to have minute precision but it show seconds too. Plus, time specified in the google forms are in UTC but users are koreans in Korea.
- Issue: #98 
closes #98 
<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Shows the form expiration time in KST.
- Fixes the UI to pass the session starting time after truncating seconds.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
