### PR TITLE
[#131] Handles 404 from sign-in and set the sign-in pop up to let users select accounts

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -27,6 +27,7 @@ func handleSignIn(server *server.Server) gin.HandlerFunc {
 		if err != nil {
 			code := getHttpStatus(err)
 			if code == http.StatusBadRequest {
+				log.Printf("Not supposed to happen but sign in failed with invalid token: %+v", err)
 				c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid token"})
 				return
 			}

--- a/server/auth.go
+++ b/server/auth.go
@@ -19,7 +19,7 @@ func (s *Server) SignIn(token string) (string, error) {
 
 	user, err := s.userRepo.GetByEmail(email)
 	if err != nil {
-		return "", newNotFoundError(fmt.Errorf("failed to get user by email: %w", err))
+		return "", newNotFoundError(fmt.Errorf("failed to get user by email (%s): %w", email, err))
 	}
 
 	rushToken, err := s.authHandler.SignIn(

--- a/ui/src/AuthContext.tsx
+++ b/ui/src/AuthContext.tsx
@@ -70,16 +70,9 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const login = useCallback(
     async (token: string) => {
       if (token) {
-        try {
-          const rushToken = await signIn(token);
-          Cookies.set(cookieName, rushToken, getCookieOptions());
-          setAuthenticated(true);
-        } catch (error) {
-          // TODO(#65): Handle this error globally.
-          // eslint-disable-next-line no-console
-          console.error(error);
-          logout();
-        }
+        const rushToken = await signIn(token);
+        Cookies.set(cookieName, rushToken, getCookieOptions());
+        setAuthenticated(true);
       }
     },
     [setAuthenticated],

--- a/ui/src/client/http.ts
+++ b/ui/src/client/http.ts
@@ -15,19 +15,17 @@ const UserSchema = z
   .object({
     id: z.string(),
     name: z.string(),
-    university: z.string(),
-    phone: z.string(),
     generation: z.number(),
     is_active: z.boolean(),
+    email: z.string(),
     external_name: z.string(),
   })
   .transform((data) => ({
     id: data.id,
     name: data.name,
-    university: data.university,
-    phone: data.phone,
     generation: data.generation,
     isActive: data.is_active,
+    email: data.email,
     externalName: data.external_name,
   }));
 

--- a/ui/src/common/GoogleSignInButton.tsx
+++ b/ui/src/common/GoogleSignInButton.tsx
@@ -1,4 +1,5 @@
 import { Button, Typography } from '@mui/material';
+import { AxiosError } from 'axios';
 import { signInWithPopup } from 'firebase/auth';
 import { useAuth } from '../AuthContext';
 import { useSnackbar } from '../SnackbarContext';
@@ -8,16 +9,22 @@ import { auth, provider } from '../firebase';
 const GoogleSignInButton = ({ text = '', callBack }: { text?: string; callBack?: () => void }) => {
   const { login } = useAuth();
   const { showInfo, showError } = useSnackbar();
-  // get the previous URL and redirect to it after login.
 
   const handleGoogleSignIn = async () => {
     try {
       const credential = await signInWithPopup(auth, provider);
       const idToken = await credential.user.getIdToken();
       await login(idToken);
-      showInfo('Successfully signed in with Google.');
       callBack?.();
+      showInfo('Successfully signed in with Google.');
     } catch (error) {
+      if (error instanceof AxiosError) {
+        if (error.response?.status === 404) {
+          showError('You are not registered in the system. Please contact the administrator.');
+          return;
+        }
+      }
+
       // TODO(#23): Handle error after centralizing the error handler.
       // eslint-disable-next-line no-console
       console.error('Error signing in with Google:', error);

--- a/ui/src/firebase.ts
+++ b/ui/src/firebase.ts
@@ -17,5 +17,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const provider = new GoogleAuthProvider();
+provider.setCustomParameters({ prompt: 'select_account' });
 
 export { auth, provider };


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
UI shows a success pop up but users could not sign in.
- Issue: #131 
- closes #131 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->
It was because the error was handled in `authContext` already. 
- Remove error catching logic in `authContext`. Let the callers handle it.
- Handles 404 error. It is returned when the users is not registered.
- Logs 401 because it's not an expected case.
- Lets users select an account when signing in.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
