### PR TITLE
[#138] Add permission package that user and auth pacakges can depend on

### DIFF
--- a/permission/role.go
+++ b/permission/role.go
@@ -1,0 +1,18 @@
+package permission
+
+type Role string
+
+const (
+	RoleNotSpecified Role = ""
+	RoleUnknown      Role = "unknown"
+	// Super admin has the highest authority.
+	// It can perform any APIs. It is for the developers or the one who has
+	// the ownership of the attendance system.
+	RoleSuperAdmin Role = "super_admin"
+	// Admin is the second highest authority.
+	// It can perform certain APIs such as creating a session, updating a session, etc.
+	RoleAdmin Role = "admin"
+	// Member is the lowest authority. They can only view certain data
+	// or access their own data.
+	RoleMember Role = "member"
+)

--- a/user/add.go
+++ b/user/add.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"fmt"
+	"rush/permission"
 )
 
 // It is separated from userRepo because it requires additional logic and it should be centralized in one place.
@@ -25,7 +26,7 @@ func (a *adder) Add(name string, generation float64, isActive bool, email string
 		Name:       name,
 		Generation: generation,
 		// Always add a user as a member first and THEN update the role if necessary.
-		Role:     RoleMember,
+		Role:     permission.RoleMember,
 		IsActive: isActive,
 		Email:    email,
 		ExternalName: func() string {

--- a/user/add_test.go
+++ b/user/add_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"rush/permission"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ func TestAdd(t *testing.T) {
 		repo.EXPECT().CountByName("name").Return(0, nil)
 		repo.EXPECT().Add(User{
 			Name:         "name",
-			Role:         RoleMember,
+			Role:         permission.RoleMember,
 			Generation:   1,
 			IsActive:     true,
 			Email:        "email",
@@ -46,7 +47,7 @@ func TestAdd(t *testing.T) {
 		repo.EXPECT().CountByName("name").Return(0, nil)
 		repo.EXPECT().Add(User{
 			Name:         "name",
-			Role:         RoleMember,
+			Role:         permission.RoleMember,
 			Generation:   1,
 			IsActive:     true,
 			Email:        "email",
@@ -61,7 +62,7 @@ func TestAdd(t *testing.T) {
 		repo.EXPECT().CountByName("name").Return(1, nil)
 		repo.EXPECT().Add(User{
 			Name:         "name",
-			Role:         RoleMember,
+			Role:         permission.RoleMember,
 			Generation:   1,
 			IsActive:     true,
 			Email:        "email",
@@ -75,7 +76,7 @@ func TestAdd(t *testing.T) {
 		repo.EXPECT().CountByName("name").Return(2, nil)
 		repo.EXPECT().Add(User{
 			Name:         "name",
-			Role:         RoleMember,
+			Role:         permission.RoleMember,
 			Generation:   1,
 			IsActive:     true,
 			Email:        "email",

--- a/user/repo.go
+++ b/user/repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"rush/permission"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -219,14 +220,14 @@ func convertToUser(user mongodbUser) (User, error) {
 	}, nil
 }
 
-func convertRole(role string) (Role, error) {
-	switch Role(role) {
-	case RoleSuperAdmin:
-		return RoleSuperAdmin, nil
-	case RoleAdmin:
-		return RoleAdmin, nil
-	case RoleMember:
-		return RoleMember, nil
+func convertRole(role string) (permission.Role, error) {
+	switch permission.Role(role) {
+	case permission.RoleSuperAdmin:
+		return permission.RoleSuperAdmin, nil
+	case permission.RoleAdmin:
+		return permission.RoleAdmin, nil
+	case permission.RoleMember:
+		return permission.RoleMember, nil
 	default:
 		return "", fmt.Errorf("invalid role: %s", role)
 	}

--- a/user/user.go
+++ b/user/user.go
@@ -1,29 +1,16 @@
 package user
 
+import "rush/permission"
+
 type User struct {
-	Id         string  `json:"id"`
-	Name       string  `json:"name"`
-	Role       Role    `json:"role"`
-	Generation float64 `json:"generation"`
-	IsActive   bool    `json:"is_active"`
-	Email      string  `json:"email"`
+	Id         string          `json:"id"`
+	Name       string          `json:"name"`
+	Role       permission.Role `json:"role"`
+	Generation float64         `json:"generation"`
+	IsActive   bool            `json:"is_active"`
+	Email      string          `json:"email"`
 	// The unique name consisting of the user name and a number.
 	// It's used as an external ID for the users so that
 	// it's easier for them to identify themselves such as in Google Forms.
 	ExternalName string `json:"external_name"`
 }
-
-type Role string
-
-const (
-	// Super admin has the highest authority.
-	// It can perform any APIs. It is for the developers or the one who has
-	// the ownership of the attendance system.
-	RoleSuperAdmin Role = "super_admin"
-	// Admin is the second highest authority.
-	// It can perform certain APIs such as creating a session, updating a session, etc.
-	RoleAdmin Role = "admin"
-	// Member is the lowest authority. They can only view certain data
-	// or access their own data.
-	RoleMember Role = "member"
-)


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
Any signed-user can call any API and we don't want that.
User role has been introduced. However, then now `auth` package should depend on `user`. And we didn't want it before.
- Issue: #138 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Introduces `permission` package.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
