### PR TITLE
[#138] Set session form and session create, session apply APIs to require admin permission

### DIFF
--- a/golang/array/array.go
+++ b/golang/array/array.go
@@ -18,3 +18,12 @@ func Filter[T any](array []T, predicate func(T) bool) []T {
 	// Adjust the capacity to the length of the result.
 	return result[:len(result):len(result)]
 }
+
+func Contains[T comparable](array []T, elem T) bool {
+	for _, e := range array {
+		if e == elem {
+			return true
+		}
+	}
+	return false
+}

--- a/http/router.go
+++ b/http/router.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"rush/permission"
 	"rush/server"
 )
 
@@ -27,11 +28,16 @@ func SetUpRouter(router *gin.Engine, server *server.Server) {
 			protected.GET("/users/:id", handleGetUser(server))
 			protected.POST("/users", handleAddUser(server))
 
-			protected.POST("/sessions", handleAddSession(server))
-			protected.POST("/sessions/:id/attendance-form", handleCreateAttendanceForm(server))
-			protected.POST("/sessions/:id/attendance", handleApplyAttendance(server))
-
+			// TODO(#138): Move it to the admin group after fixing the UI to handle permission denied error on it more properly.
 			protected.GET("attendances/half-year", handleHalfYearAttendance(server))
+
+			adminProtected := protected.Group("/")
+			adminProtected.Use(RequireRole(permission.RoleAdmin, permission.RoleSuperAdmin))
+			{
+				adminProtected.POST("/sessions", handleAddSession(server))
+				adminProtected.POST("/sessions/:id/attendance-form", handleCreateAttendanceForm(server))
+				adminProtected.POST("/sessions/:id/attendance", handleApplyAttendance(server))
+			}
 		}
 	}
 

--- a/ui/src/SessionCreate.tsx
+++ b/ui/src/SessionCreate.tsx
@@ -29,10 +29,22 @@ const SessionCreate = () => {
       const id = await createSession(name, description, new Date(startsAt.toISOString()), score);
       navigate(`/sessions/${id}`);
     } catch (error: unknown) {
-      if (error instanceof AxiosError && error.response?.status === 401) {
-        showWarning('Session creation is restricted to authenticated users');
-      } else {
-        showError('Failed to create a form. Contact the administrator.');
+      if (!(error instanceof AxiosError)) {
+        showError('An unexpected error occurred. Please contact the administrator.');
+        return;
+      }
+
+      const status = error.response?.status;
+      switch (status) {
+        case 401:
+          showWarning('Session creation is restricted to admin users');
+          break;
+        case 403:
+          showWarning('Session creation is restricted to admin users');
+          break;
+        default:
+          showError('An unexpected error occurred. Please contact the administrator.');
+          break;
       }
     }
   };

--- a/ui/src/SessionDetail.tsx
+++ b/ui/src/SessionDetail.tsx
@@ -72,11 +72,11 @@ const SessionDetail = () => {
       const updatedSession = await getSession(id);
       setSession(updatedSession);
     } catch (error) {
-      handleError(
+      handleError({
         error,
-        'Form creation is restricted to authenticated users',
-        'Failed to create a form. Contact the administrator.',
-      );
+        messageAuth: 'Form creation is restricted to authenticated users',
+        messageInternal: 'Failed to create a form. Contact the dev.',
+      });
     } finally {
       setIsCreatingForm(false);
     }
@@ -89,21 +89,41 @@ const SessionDetail = () => {
       const updatedSession = await getSession(id);
       setSession(updatedSession);
     } catch (error) {
-      handleError(
+      handleError({
         error,
-        'Form closing is restricted to authenticated users',
-        'Failed to close the form. Contact the administrator.',
-      );
+        messageAuth: 'Form closing is restricted to admin users',
+        messageInternal: 'Failed to close the session. Contact the dev.',
+      });
     } finally {
       setIsClosingSession(false);
     }
   };
 
-  const handleError = (error: unknown, warningMessage: string, errorMessage: string) => {
-    if (error instanceof AxiosError && error.response?.status === 401) {
-      showWarning(warningMessage);
-    } else {
-      showError(errorMessage);
+  const handleError = ({
+    error,
+    messageAuth,
+    messageInternal,
+  }: {
+    error: unknown;
+    messageAuth: string;
+    messageInternal: string;
+  }) => {
+    if (!(error instanceof AxiosError)) {
+      showError(messageInternal);
+      return;
+    }
+
+    const status = error.response?.status;
+    switch (status) {
+      case 401:
+        showWarning(messageAuth);
+        break;
+      case 403:
+        showWarning(messageAuth);
+        break;
+      default:
+        showError(messageInternal);
+        break;
     }
   };
 


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
Any signed-in user can create, close sessions. They're not supposed to.
- Issue: #138 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Fixes the followings to be admin-required.
```go
adminProtected.POST("/sessions", handleAddSession(server))
adminProtected.POST("/sessions/:id/attendance-form", handleCreateAttendanceForm(server))
adminProtected.POST("/sessions/:id/attendance", handleApplyAttendance(server))
```
- Fixes the UI to handle 403 error from those APIs.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
