### PR TITLE
[#145] Fix session job to return succeeded IDs and implement GetOpenSessions in repo

### DIFF
--- a/job/session_mock.go
+++ b/job/session_mock.go
@@ -77,10 +77,10 @@ func (m *MocksessionGetter) EXPECT() *MocksessionGetterMockRecorder {
 }
 
 // GetOpenSessions mocks base method.
-func (m *MocksessionGetter) GetOpenSessions() ([]*session.Session, error) {
+func (m *MocksessionGetter) GetOpenSessions() ([]session.Session, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOpenSessions")
-	ret0, _ := ret[0].([]*session.Session)
+	ret0, _ := ret[0].([]session.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/job/session_test.go
+++ b/job/session_test.go
@@ -15,7 +15,7 @@ func TestCloseSessions(t *testing.T) {
 		sessionCloser := NewMocksessionCloser(controller)
 		executor := NewExecutor(sessionGetter, sessionCloser)
 
-		sessionGetter.EXPECT().GetOpenSessions().Return([]*session.Session{}, assert.AnError)
+		sessionGetter.EXPECT().GetOpenSessions().Return([]session.Session{}, assert.AnError)
 		result, err := executor.CloseSessions()
 
 		assert.Equal(t, CloseSessionsResult{}, result)
@@ -28,7 +28,7 @@ func TestCloseSessions(t *testing.T) {
 		sessionCloser := NewMocksessionCloser(controller)
 		executor := NewExecutor(sessionGetter, sessionCloser)
 
-		sessionGetter.EXPECT().GetOpenSessions().Return([]*session.Session{
+		sessionGetter.EXPECT().GetOpenSessions().Return([]session.Session{
 			{Id: "sessionId1"},
 			{Id: "sessionId2"},
 			{Id: "sessionId3"},
@@ -39,8 +39,9 @@ func TestCloseSessions(t *testing.T) {
 		result, err := executor.CloseSessions()
 
 		assert.Equal(t, CloseSessionsResult{
-			failedSessionIds: []string{"sessionId1", "sessionId3"},
-			errors:           []error{assert.AnError, assert.AnError},
+			SessionIdsSucceeded: []string{"sessionId2"},
+			FailedSessionIds:    []string{"sessionId1", "sessionId3"},
+			Errors:              []error{assert.AnError, assert.AnError},
 		}, result)
 		assert.EqualError(t, err, "failed to close some sessions")
 	})
@@ -51,7 +52,7 @@ func TestCloseSessions(t *testing.T) {
 		sessionCloser := NewMocksessionCloser(controller)
 		executor := NewExecutor(sessionGetter, sessionCloser)
 
-		sessionGetter.EXPECT().GetOpenSessions().Return([]*session.Session{
+		sessionGetter.EXPECT().GetOpenSessions().Return([]session.Session{
 			{Id: "sessionId1"},
 			{Id: "sessionId2"},
 		}, nil)
@@ -59,7 +60,9 @@ func TestCloseSessions(t *testing.T) {
 		sessionCloser.EXPECT().CloseSession("sessionId2").Return(nil)
 		result, err := executor.CloseSessions()
 
-		assert.Equal(t, CloseSessionsResult{}, result)
+		assert.Equal(t, CloseSessionsResult{
+			SessionIdsSucceeded: []string{"sessionId1", "sessionId2"},
+		}, result)
 		assert.NoError(t, err)
 	})
 }

--- a/session/repo.go
+++ b/session/repo.go
@@ -66,6 +66,26 @@ func (r *mongodbRepo) Get(id string) (*Session, error) {
 	return fromMongodbSession(session), nil
 }
 
+func (r *mongodbRepo) GetOpenSessions() ([]Session, error) {
+	cursor, err := r.collection.Find(context.Background(), bson.M{"is_closed": false})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get sessions: %w", err)
+	}
+	defer cursor.Close(context.Background())
+
+	var mongoSessions []mongodbSession
+	if err = cursor.All(context.Background(), &mongoSessions); err != nil {
+		return nil, fmt.Errorf("failed to decode sessions: %w", err)
+	}
+
+	sessions := []Session{}
+	for _, mongoSession := range mongoSessions {
+		sessions = append(sessions, *fromMongodbSession(&mongoSession))
+	}
+
+	return sessions, nil
+}
+
 func (r *mongodbRepo) GetAll() ([]Session, error) {
 	cursor, err := r.collection.Find(context.Background(), bson.M{})
 	if err != nil {


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
Session repo doesn't provide a feature to get open sessions. and also it's hard to know which session has been closed.
- Issue: #145 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Implements `GetOpenSessions`.
- Fixes the session job result to return the succeeded IDs too.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
