### PR TITLE
[#145] Fixes the job executor to close the expired sessions only

### DIFF
--- a/job/session.go
+++ b/job/session.go
@@ -4,16 +4,19 @@ import (
 	"fmt"
 	"rush/golang/array"
 	"rush/session"
+
+	"github.com/benbjohnson/clock"
 )
 
 type executor struct {
 	sessionGetter sessionGetter
 	sessionCloser sessionCloser
+	clock         clock.Clock
 }
 
-type CloseSessionsResult struct {
+type CloseExpiredSessionsResult struct {
 	// The IDs of the sessions that succeeded to close.
-	SessionIdsSucceeded []string
+	SucceededSessionIds []string
 	// The IDs of the sessions that failed to close.
 	FailedSessionIds []string
 	// The errors that occurred while closing the sessions.
@@ -21,43 +24,46 @@ type CloseSessionsResult struct {
 	Errors []error
 }
 
-func NewExecutor(sessionGetter sessionGetter, sessionCloser sessionCloser) *executor {
+func NewExecutor(sessionGetter sessionGetter, sessionCloser sessionCloser, clock clock.Clock) *executor {
 	return &executor{
 		sessionGetter: sessionGetter,
 		sessionCloser: sessionCloser,
+		clock:         clock,
 	}
 }
 
-func (e *executor) CloseSessions() (CloseSessionsResult, error) {
+// Closes the open sessions that are past the start time.
+func (e *executor) CloseExpiredSessions() (CloseExpiredSessionsResult, error) {
 	openSessions, err := e.sessionGetter.GetOpenSessions()
 	if err != nil {
-		return CloseSessionsResult{}, fmt.Errorf("failed to get open sessions: %w", err)
+		return CloseExpiredSessionsResult{}, fmt.Errorf("failed to get open sessions: %w", err)
 	}
 
-	failedSessions := []string{}
+	openSessions = array.Filter(openSessions, func(session session.Session) bool {
+		return session.StartsAt.Before(e.clock.Now()) || session.StartsAt.Equal(e.clock.Now())
+	})
+
+	failedSessionIds := []string{}
+	succeededSessionIds := []string{}
 	errors := []error{}
 	for _, session := range openSessions {
 		if err := e.sessionCloser.CloseSession(session.Id); err != nil {
-			failedSessions = append(failedSessions, session.Id)
+			failedSessionIds = append(failedSessionIds, session.Id)
 			errors = append(errors, err)
+			continue
 		}
+		succeededSessionIds = append(succeededSessionIds, session.Id)
 	}
 
-	sessionsSucceeded := array.Filter(openSessions, func(session session.Session) bool {
-		return !array.Contains(failedSessions, session.Id)
-	})
-	sessionIdsSucceeded := array.Map(sessionsSucceeded, func(session session.Session) string {
-		return session.Id
-	})
-	if len(failedSessions) == 0 {
-		return CloseSessionsResult{
-			SessionIdsSucceeded: sessionIdsSucceeded,
+	if len(failedSessionIds) == 0 {
+		return CloseExpiredSessionsResult{
+			SucceededSessionIds: succeededSessionIds,
 		}, nil
 	}
 
-	return CloseSessionsResult{
-		SessionIdsSucceeded: sessionIdsSucceeded,
-		FailedSessionIds:    failedSessions,
+	return CloseExpiredSessionsResult{
+		SucceededSessionIds: succeededSessionIds,
+		FailedSessionIds:    failedSessionIds,
 		Errors:              errors,
 	}, fmt.Errorf("failed to close some sessions")
 }


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
The session closer has been implemented to close all the open sessions, although it is supposed to close both the open and expired sessions (those whose starting time has passed).
- Issue: #145 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Fixes the session closer to close the open AND expired ones.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
