### PR TITLE
[#173] Add status about session attandance

### DIFF
--- a/server/attendance.go
+++ b/server/attendance.go
@@ -18,7 +18,7 @@ func (s *Server) CreateAttendanceForm(sessionId string) (string, error) {
 	if err != nil {
 		return "", newNotFoundError(fmt.Errorf("failed to get session: %w", err))
 	}
-	if dbSession.IsClosed {
+	if !dbSession.CanUpdateMetadata() {
 		return "", newBadRequestError(errors.New("session is already closed"))
 	}
 

--- a/server/converter.go
+++ b/server/converter.go
@@ -17,18 +17,18 @@ func fromUser(user *user.User) *User {
 	}
 }
 
-func fromSession(session session.Session) Session {
+func fromSession(dbSession session.Session) Session {
 	return Session{
-		Id:            session.Id,
-		Name:          session.Name,
-		Description:   session.Description,
-		CreatedBy:     session.CreatedBy,
-		GoogleFormUri: session.GoogleFormUri,
-		GoogleFormId:  session.GoogleFormId,
-		CreatedAt:     session.CreatedAt,
-		StartsAt:      session.StartsAt,
-		Score:         session.Score,
-		IsClosed:      session.IsClosed,
+		Id:            dbSession.Id,
+		Name:          dbSession.Name,
+		Description:   dbSession.Description,
+		CreatedBy:     dbSession.CreatedBy,
+		GoogleFormUri: dbSession.GoogleFormUri,
+		GoogleFormId:  dbSession.GoogleFormId,
+		CreatedAt:     dbSession.CreatedAt,
+		StartsAt:      dbSession.StartsAt,
+		Score:         dbSession.Score,
+		IsClosed:      dbSession.AttendanceStatus == session.AttendanceStatusApplied,
 	}
 }
 

--- a/server/session.go
+++ b/server/session.go
@@ -61,7 +61,7 @@ func (s *Server) CloseSession(sessionId string) error {
 		return newNotFoundError(fmt.Errorf("failed to get session: %w", err))
 	}
 
-	if dbSession.IsClosed {
+	if !dbSession.CanUpdateMetadata() {
 		return newBadRequestError(errors.New("session is already closed"))
 	}
 

--- a/session/repo.go
+++ b/session/repo.go
@@ -12,17 +12,17 @@ import (
 )
 
 type mongodbSession struct {
-	Id            primitive.ObjectID `bson:"_id,omitempty"`
-	Name          string             `bson:"name"`
-	Description   string             `bson:"description"`
-	CreatedBy     string             `bson:"created_by"`
-	GoogleFormId  string             `bson:"google_form_id"`
-	GoogleFormUri string             `bson:"google_form_uri"`
-	CreatedAt     time.Time          `bson:"created_at"`
-	StartsAt      time.Time          `bson:"starts_at"`
-	Score         int                `bson:"score"`
-	IsClosed      bool               `bson:"is_closed"`
-	IsDeleted     bool               `bson:"is_deleted"`
+	Id               primitive.ObjectID `bson:"_id,omitempty"`
+	Name             string             `bson:"name"`
+	Description      string             `bson:"description"`
+	CreatedBy        string             `bson:"created_by"`
+	GoogleFormId     string             `bson:"google_form_id"`
+	GoogleFormUri    string             `bson:"google_form_uri"`
+	CreatedAt        time.Time          `bson:"created_at"`
+	StartsAt         time.Time          `bson:"starts_at"`
+	Score            int                `bson:"score"`
+	AttendanceStatus AttendanceStatus   `bson:"attendance_status"`
+	IsDeleted        bool               `bson:"is_deleted"`
 }
 
 type mongodbRepo struct {
@@ -35,9 +35,9 @@ type UpdateForm struct {
 	GoogleFormId  *string
 	GoogleFormUri *string
 	// It should be updated with the form's description.
-	StartsAt *time.Time
-	Score    *int
-	IsClosed *bool
+	StartsAt         *time.Time
+	Score            *int
+	AttendanceStatus *AttendanceStatus
 
 	// Indicator to return the updated session.
 	ReturnUpdatedSession bool
@@ -156,16 +156,16 @@ func (r *mongodbRepo) List(offset int, pageSize int) (*ListResult, error) {
 
 func (r *mongodbRepo) Add(name string, description string, createdBy string, startsAt time.Time, score int) (string, error) {
 	session := mongodbSession{
-		Name:          name,
-		Description:   description,
-		CreatedBy:     createdBy,
-		GoogleFormId:  "",
-		GoogleFormUri: "",
-		CreatedAt:     time.Now(),
-		StartsAt:      startsAt,
-		Score:         score,
-		IsClosed:      false,
-		IsDeleted:     false,
+		Name:             name,
+		Description:      description,
+		CreatedBy:        createdBy,
+		GoogleFormId:     "",
+		GoogleFormUri:    "",
+		CreatedAt:        time.Now(),
+		StartsAt:         startsAt,
+		Score:            score,
+		AttendanceStatus: AttendanceStatusNotAppliedYet,
+		IsDeleted:        false,
 	}
 
 	result, err := r.collection.InsertOne(context.Background(), session)
@@ -206,8 +206,8 @@ func (r *mongodbRepo) Update(id string, updateForm UpdateForm) (Session, error) 
 	if updateForm.Score != nil {
 		update["score"] = *updateForm.Score
 	}
-	if updateForm.IsClosed != nil {
-		update["is_closed"] = *updateForm.IsClosed
+	if updateForm.AttendanceStatus != nil {
+		update["attendance_status"] = *updateForm.AttendanceStatus
 	}
 
 	if _, err = r.collection.UpdateOne(context.Background(), bson.M{"_id": objectID}, bson.M{"$set": update}); err != nil {
@@ -237,15 +237,15 @@ func (r *mongodbRepo) Delete(id string) error {
 
 func fromMongodbSession(session *mongodbSession) *Session {
 	return &Session{
-		Id:            session.Id.Hex(),
-		Name:          session.Name,
-		Description:   session.Description,
-		CreatedBy:     session.CreatedBy,
-		GoogleFormId:  session.GoogleFormId,
-		GoogleFormUri: session.GoogleFormUri,
-		CreatedAt:     session.CreatedAt,
-		StartsAt:      session.StartsAt,
-		Score:         session.Score,
-		IsClosed:      session.IsClosed,
+		Id:               session.Id.Hex(),
+		Name:             session.Name,
+		Description:      session.Description,
+		CreatedBy:        session.CreatedBy,
+		GoogleFormId:     session.GoogleFormId,
+		GoogleFormUri:    session.GoogleFormUri,
+		CreatedAt:        session.CreatedAt,
+		StartsAt:         session.StartsAt,
+		Score:            session.Score,
+		AttendanceStatus: session.AttendanceStatus,
 	}
 }

--- a/session/service.go
+++ b/session/service.go
@@ -21,7 +21,7 @@ func (s *service) DeleteOpenSession(id string) error {
 	if err != nil {
 		return fmt.Errorf("repo failed to get session: %w", err)
 	}
-	if session.IsClosed {
+	if !session.CanUpdateMetadata() {
 		return errors.New("session is already closed")
 	}
 
@@ -48,7 +48,7 @@ func (s *service) UpdateOpenSession(id string, updateForm OpenSessionUpdateForm)
 	if err != nil {
 		return Session{}, fmt.Errorf("repo failed to get session: %w", err)
 	}
-	if session.IsClosed {
+	if !session.CanUpdateMetadata() {
 		return Session{}, errors.New("session is already closed")
 	}
 
@@ -70,8 +70,8 @@ func (s *service) UpdateOpenSession(id string, updateForm OpenSessionUpdateForm)
 }
 
 func (s *service) CloseOpenSession(id string) error {
-	closed := true
-	_, err := s.sessionRepo.Update(id, UpdateForm{IsClosed: &closed})
+	attendanceStatus := AttendanceStatusApplied
+	_, err := s.sessionRepo.Update(id, UpdateForm{AttendanceStatus: &attendanceStatus})
 	if err != nil {
 		return fmt.Errorf("repo failed to update session: %w", err)
 	}

--- a/session/service_test.go
+++ b/session/service_test.go
@@ -27,7 +27,7 @@ func TestDeleteOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: true}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusApplied}, nil)
 		err := service.DeleteOpenSession("session-id")
 
 		assert.Equal(t, errors.New("session is already closed"), err)
@@ -38,7 +38,7 @@ func TestDeleteOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: false}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusNotAppliedYet}, nil)
 		sessionRepo.EXPECT().Delete("session-id").Return(errors.New("failed to delete session"))
 		err := service.DeleteOpenSession("session-id")
 
@@ -50,7 +50,7 @@ func TestDeleteOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: false}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusNotAppliedYet}, nil)
 		sessionRepo.EXPECT().Delete("session-id").Return(nil)
 		err := service.DeleteOpenSession("session-id")
 
@@ -75,7 +75,7 @@ func TestUpdateOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: true}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusApplied}, nil)
 		_, err := service.UpdateOpenSession("session-id", OpenSessionUpdateForm{})
 
 		assert.Equal(t, errors.New("session is already closed"), err)
@@ -86,7 +86,7 @@ func TestUpdateOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: false}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusNotAppliedYet}, nil)
 		newTitle := "new-title"
 		newDescription := "new-description"
 		newStartsAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -118,7 +118,7 @@ func TestUpdateOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		sessionRepo.EXPECT().Get("session-id").Return(Session{IsClosed: false}, nil)
+		sessionRepo.EXPECT().Get("session-id").Return(Session{AttendanceStatus: AttendanceStatusNotAppliedYet}, nil)
 		newTitle := "new-title"
 		newDescription := "new-description"
 		newStartsAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -140,7 +140,6 @@ func TestUpdateOpenSession(t *testing.T) {
 			Description:   newDescription,
 			StartsAt:      newStartsAt,
 			Score:         newScore,
-			IsClosed:      false,
 			CreatedBy:     "created-by",
 			GoogleFormId:  newGoogleFormId,
 			GoogleFormUri: newGoogleFormUri,
@@ -170,9 +169,9 @@ func TestCloseOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		isClosed := true
+		attendanceStatus := AttendanceStatusApplied
 		sessionRepo.EXPECT().Update("session-id", UpdateForm{
-			IsClosed: &isClosed,
+			AttendanceStatus: &attendanceStatus,
 		}).Return(Session{}, errors.New("failed to update session"))
 		err := service.CloseOpenSession("session-id")
 
@@ -184,9 +183,9 @@ func TestCloseOpenSession(t *testing.T) {
 		sessionRepo := NewMockSessionRepo(controller)
 		service := NewService(sessionRepo)
 
-		isClosed := true
+		attendanceStatus := AttendanceStatusApplied
 		sessionRepo.EXPECT().Update("session-id", UpdateForm{
-			IsClosed: &isClosed,
+			AttendanceStatus: &attendanceStatus,
 		}).Return(Session{}, nil)
 
 		err := service.CloseOpenSession("session-id")

--- a/session/session.go
+++ b/session/session.go
@@ -23,7 +23,22 @@ type Session struct {
 	StartsAt time.Time `json:"starts_at"`
 	// The attendance score of the session that the user can get. E.g., 2
 	Score int `json:"score"`
-	// If the session is closed, no one can fix the metadata besides the developer.
-	// It's to prevent cheating. E.g., false
-	IsClosed bool `json:"is_closed"`
+	// The status of the session's attendance.
+	// It indicates if it is applied, ignored, etc.
+	AttendanceStatus AttendanceStatus `json:"attendance_status"`
+}
+
+type AttendanceStatus string
+
+const (
+	// not applied yet.
+	AttendanceStatusNotAppliedYet AttendanceStatus = "not_applied_yet"
+	// The attendance has been applied. Once it's applied, the session data is immutable.
+	AttendanceStatusApplied AttendanceStatus = "applied"
+	// It has been tried to apply the attendance but ignored for some reasons. It should be checked manually.
+	AttendanceStatusIgnored AttendanceStatus = "ignored"
+)
+
+func (s *Session) CanUpdateMetadata() bool {
+	return s.AttendanceStatus == AttendanceStatusNotAppliedYet || s.AttendanceStatus == AttendanceStatusIgnored
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,20 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSession_CanUpdateMetadata(t *testing.T) {
+	session := Session{
+		AttendanceStatus: AttendanceStatusNotAppliedYet,
+	}
+	assert.True(t, session.CanUpdateMetadata())
+
+	session.AttendanceStatus = AttendanceStatusIgnored
+	assert.True(t, session.CanUpdateMetadata())
+
+	session.AttendanceStatus = AttendanceStatusApplied
+	assert.False(t, session.CanUpdateMetadata())
+}


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
when syncing attendance, there's a chance where an empty session's attendance is applied.
- Issue: #173 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->
To not apply session attendance in certain cases, and let users know about it, it introduces session attendance status.
- Introduces session attendance status. It is not exposed to the UI yet.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->
Ignore attendance application when there's no submission, and update the status to be `ignored`.
<!-- Tasks to be completed after this PR. -->
