### PR TITLE
[#187] Let admins make sessions that had started in the past

### DIFF
--- a/ui/src/SessionCreate.tsx
+++ b/ui/src/SessionCreate.tsx
@@ -18,9 +18,8 @@ const SessionCreate = () => {
 
   useEffect(() => {
     const isNameValid = name.trim().length > 0;
-    const isStartsAtValid = startsAt.isAfter(dayjs());
-    setIsFormValid(isNameValid && isStartsAtValid);
-  }, [name, startsAt]);
+    setIsFormValid(isNameValid);
+  }, [name]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -84,17 +83,10 @@ const SessionCreate = () => {
           value={startsAt}
           onChange={handleDateTimeChange}
           minutesStep={10}
-          shouldDisableDate={(date) => date.isBefore(dayjs(), 'day')}
           views={['year', 'month', 'day', 'hours', 'minutes']}
           format="YYYY/MM/DD HH:mm"
           skipDisabled
           sx={{ mb: 2, width: '100%' }}
-          slotProps={{
-            textField: {
-              helperText: startsAt.isBefore(dayjs()) ? 'Start time must be in the future' : '',
-              error: startsAt.isBefore(dayjs()),
-            },
-          }}
         />
         <TextField
           type="number"


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
Admins can not make sessions that had started in the past. it's necessary as they sometimes manually add attendances after the sessions is done.
- Issue: #187 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Fix the validation in the UI that was prevent admins from making sessions that had held in the past.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
