### PR TITLE
[#200] Fix `GetHalfYearAttendance` to map sessions based on its ID, not its name

### DIFF
--- a/server/attendance.go
+++ b/server/attendance.go
@@ -142,17 +142,17 @@ func (s *Server) GetHalfYearAttendance() (HalfYearAttendace, error) {
 		convertedAttendances = append(convertedAttendances, *fromAttendance(&attendance))
 	}
 
-	uniqueSessionMap := map[string]sessionForAttendance{}
+	idSessionMap := map[string]sessionForAttendance{}
 	for _, attendance := range convertedAttendances {
-		uniqueSessionMap[attendance.SessionName] = sessionForAttendance{
+		idSessionMap[attendance.SessionId] = sessionForAttendance{
 			Id:        attendance.SessionId,
 			Name:      attendance.SessionName,
 			StartedAt: attendance.SessionStartedAt,
 		}
 	}
 	uniqueSessions := []sessionForAttendance{}
-	for name := range uniqueSessionMap {
-		uniqueSessions = append(uniqueSessions, uniqueSessionMap[name])
+	for id := range idSessionMap {
+		uniqueSessions = append(uniqueSessions, idSessionMap[id])
 	}
 	slices.SortStableFunc(uniqueSessions, func(session1, session2 sessionForAttendance) int {
 		if session1.StartedAt.After(session2.StartedAt) {
@@ -181,9 +181,9 @@ func (s *Server) AggregateAttendance() error {
 		return newInternalServerError(fmt.Errorf("failed to get all attendances: %w", err))
 	}
 
-	userScoreMap := map[string]int{}
+	userIdScoreMap := map[string]int{}
 	for _, attendance := range attendances {
-		userScoreMap[attendance.UserId] += attendance.SessionScore
+		userIdScoreMap[attendance.UserId] += attendance.SessionScore
 	}
 
 	sessionIdSet := map[string]bool{}
@@ -196,7 +196,7 @@ func (s *Server) AggregateAttendance() error {
 	}
 
 	userInfosForAggregation := array.Map(attendances, func(attendance attendance.Attendance) attendanceAggregation.UserInfo {
-		userScore, ok := userScoreMap[attendance.UserId]
+		userScore, ok := userIdScoreMap[attendance.UserId]
 		if !ok {
 			userScore = 0
 		}


### PR DESCRIPTION
…name

<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->
some sessions were not found in the half-year attendance.
- Issue: #200 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->
It was aggregating the attendance data based on session name, not ID.
 - Fix `GetHalfYearAttendance` to map sessions based on its ID, not its name

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
