### PR TITLE
[#60] Remove `ListUsers` and fix `GetAllUsers` to return only active ones

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -69,62 +69,14 @@ func handleAuth(server *server.Server) gin.HandlerFunc {
 
 func handleListUsers(server *server.Server) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		onlyActiveQuery := c.Query("onlyActive")
-		onlyActive := false
-		if onlyActiveQuery != "" && onlyActiveQuery != "0" && onlyActiveQuery != "1" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid onlyActive"})
-			return
-		}
-		if onlyActiveQuery == "1" {
-			onlyActive = true
-		} else if onlyActiveQuery == "0" {
-			onlyActive = false
-		}
-
-		allQuery := c.Query("all")
-		if allQuery != "" && allQuery != "1" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid all"})
-			return
-		}
-		if allQuery == "1" {
-			result, err := server.ListUsers(0, 0, onlyActive, true /* =all */)
-			if err != nil {
-				log.Printf("Error getting users: %+v", err)
-				c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
-				return
-			}
-
-			c.JSON(http.StatusOK, gin.H{
-				"users":       result.Users,
-				"is_end":      result.IsEnd,
-				"total_count": result.TotalCount,
-			})
-			return
-		}
-
-		offset, err := strconv.Atoi(c.Query("offset"))
-		if err != nil || offset < 0 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid offset"})
-			return
-		}
-		pageSize, err := strconv.Atoi(c.Query("pageSize"))
-		if err != nil || pageSize < 1 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid pageSize"})
-			return
-		}
-
-		result, err := server.ListUsers(offset, pageSize, onlyActive, false /* =all */)
+		users, err := server.GetAllActiveUsers()
 		if err != nil {
 			log.Printf("Error getting users: %+v", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{
-			"users":       result.Users,
-			"is_end":      result.IsEnd,
-			"total_count": result.TotalCount,
-		})
+		c.JSON(http.StatusOK, users)
 	}
 }
 

--- a/server/user.go
+++ b/server/user.go
@@ -6,87 +6,21 @@ import (
 	"rush/user"
 )
 
-func (s *Server) GetAllUsers() ([]*User, error) {
+func (s *Server) GetAllActiveUsers() ([]*User, error) {
 	users, err := s.userRepo.GetAll()
 	if err != nil {
 		return nil, newInternalServerError(fmt.Errorf("failed to get users: %w", err))
 	}
 
+	activeUsers := array.Filter(users, func(user user.User) bool {
+		return user.IsActive
+	})
+
 	converted := []*User{}
-	for _, user := range users {
+	for _, user := range activeUsers {
 		converted = append(converted, fromUser(&user))
 	}
 	return converted, nil
-}
-
-type ListUsersResult struct {
-	Users      []User `json:"users"`
-	IsEnd      bool   `json:"is_end"`
-	TotalCount int    `json:"total_count"`
-}
-
-// Returns the list of users.
-// If `all` is true, it returns all the users.
-// If `onlyActive` is true, it returns only the active users.
-func (s *Server) ListUsers(offset int, pageSize int, onlyActive bool, all bool) (*ListUsersResult, error) {
-	if all {
-		if onlyActive {
-			users, err := s.userRepo.GetAllActive()
-			if err != nil {
-				return nil, err
-			}
-
-			converted := []User{}
-			for _, user := range users {
-				converted = append(converted, *fromUser(&user))
-			}
-			return &ListUsersResult{
-				Users:      converted,
-				IsEnd:      true,
-				TotalCount: len(users),
-			}, nil
-		}
-		users, err := s.userRepo.GetAll()
-		if err != nil {
-			return nil, err
-		}
-
-		converted := []User{}
-		for _, user := range users {
-			converted = append(converted, *fromUser(&user))
-		}
-		return &ListUsersResult{
-			Users:      converted,
-			IsEnd:      true,
-			TotalCount: len(users),
-		}, nil
-	}
-
-	listResult, err := s.userRepo.List(offset, pageSize)
-	if err != nil {
-		return nil, newInternalServerError(fmt.Errorf("failed to list users: %w", err))
-	}
-
-	converted := []User{}
-	for _, user := range listResult.Users {
-		converted = append(converted, *fromUser(&user))
-	}
-
-	if onlyActive {
-		return &ListUsersResult{
-			Users: array.Filter(converted, func(user User) bool {
-				return user.IsActive
-			}),
-			IsEnd:      listResult.IsEnd,
-			TotalCount: listResult.TotalCount,
-		}, nil
-	}
-
-	return &ListUsersResult{
-		Users:      converted,
-		IsEnd:      listResult.IsEnd,
-		TotalCount: listResult.TotalCount,
-	}, nil
 }
 
 // Returns the user by the given ID.

--- a/server/user_test.go
+++ b/server/user_test.go
@@ -1,0 +1,84 @@
+package server
+
+import (
+	"fmt"
+	"rush/permission"
+	"rush/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	gomock "go.uber.org/mock/gomock"
+)
+
+func TestGetAllActiveUsers(t *testing.T) {
+	t.Run("Returns internal server error when failed to get users", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockUserRepo := NewMockuserRepo(ctrl)
+		server := New(nil, nil, mockUserRepo, nil, nil, nil, nil, nil, nil, nil, nil)
+
+		mockUserRepo.EXPECT().GetAll().Return(nil, assert.AnError)
+		users, err := server.GetAllActiveUsers()
+
+		assert.Nil(t, users)
+		assert.Equal(t, &InternalServerError{originalError: fmt.Errorf("failed to get users: %w", assert.AnError)}, err)
+	})
+
+	t.Run("Returns only active users when successfully gets users", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockUserRepo := NewMockuserRepo(ctrl)
+		server := New(nil, nil, mockUserRepo, nil, nil, nil, nil, nil, nil, nil, nil)
+
+		mockUserRepo.EXPECT().GetAll().Return([]user.User{
+			{
+				Id:           "user-id",
+				Name:         "user-name",
+				Role:         permission.RoleMember,
+				Generation:   9.5,
+				IsActive:     true,
+				Email:        "user-email",
+				ExternalName: "user-external-name",
+			},
+			{
+				Id:           "user-id2",
+				Name:         "user-name2",
+				Role:         permission.RoleMember,
+				Generation:   9.5,
+				IsActive:     false,
+				Email:        "user-email2",
+				ExternalName: "user-external-name2",
+			},
+			{
+				Id:           "user-id3",
+				Name:         "user-name3",
+				Role:         permission.RoleMember,
+				Generation:   9.5,
+				IsActive:     true,
+				Email:        "user-email3",
+				ExternalName: "user-external-name3",
+			},
+		}, nil)
+		users, err := server.GetAllActiveUsers()
+
+		assert.Equal(t, []*User{
+			{
+				Id:           "user-id",
+				Name:         "user-name",
+				Generation:   9.5,
+				IsActive:     true,
+				Email:        "user-email",
+				ExternalName: "user-external-name",
+			},
+			{
+				Id:           "user-id3",
+				Name:         "user-name3",
+				Generation:   9.5,
+				IsActive:     true,
+				Email:        "user-email3",
+				ExternalName: "user-external-name3",
+			},
+		}, users)
+		assert.NoError(t, err)
+	})
+}

--- a/ui/src/client/http/admin.ts
+++ b/ui/src/client/http/admin.ts
@@ -15,19 +15,13 @@ const client: AxiosInstance = axios.create({
 
 client.interceptors.response.use(setToken);
 
-const AdminAllActiveUsersResponseSchema = z.object({
-  users: z.array(UserSchema),
-  is_end: z.boolean(),
-  total_count: z.number(),
-});
-
-const Users = z.array(UserSchema);
+const AdminAllActiveUsersResponseSchema = z.array(UserSchema);
 
 export type AdminAllActiveUsersResponse = z.infer<typeof Users>;
 
 export const adminAllActiveUsers = async (): Promise<AdminAllActiveUsersResponse> => {
-  const response = await client.get('/users', { params: { offset: 0, pageSize: 0, onlyActive: 1, all: 1 } });
-  return AdminAllActiveUsersResponseSchema.parse(response.data).users;
+  const response = await client.get('/users');
+  return AdminAllActiveUsersResponseSchema.parse(response.data);
 };
 
 const AdminGetSessionResponseSchema = AdminSessionSchema;


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->

- Issue: #60 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Remove `ListUsers`. Currently, the web client only needs an API to handle all active users. It does way too much. `GetAllUsers` can handle it.
- Fix `GetAllUsers` to return only active users.
- Implement tests for `GetAllActiveUsers`.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
