### PR TITLE
[#57|#209] Separate admin session components from user ones

### DIFF
--- a/ui/src/Routes.tsx
+++ b/ui/src/Routes.tsx
@@ -1,13 +1,15 @@
 import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom';
 import SignIn from './SignIn';
 import AdminLayout from './admin/Layout';
+import AdminSessionDetail from './admin/SessionDetail';
+import AdminSessionList from './admin/SessionList';
 import { useAuth } from './auth';
 import { Role } from './auth/role';
 import HalfYearAttendances from './user/Attendance';
 import UserLayout from './user/Layout';
 import MyPage from './user/MyPage';
-import { AdminSessionDetail, UserSessionDetail } from './user/SessionDetail';
-import { AdminSessionList, UserSessionList } from './user/SessionList';
+import UserSessionDetail from './user/SessionDetail';
+import UserSessionList from './user/SessionList';
 
 const AppRoutes = () => (
   <Routes>

--- a/ui/src/admin/SessionDetail/AddAttendance.tsx
+++ b/ui/src/admin/SessionDetail/AddAttendance.tsx
@@ -11,9 +11,9 @@ import {
   Typography,
 } from '@mui/material';
 import { DataGrid, GridRowSelectionModel, GridToolbarContainer, GridToolbarQuickFilter } from '@mui/x-data-grid';
-import { adminAllActiveUsers } from '../../../client/http/admin';
-import { User } from '../../../client/http/data';
-import useHandleError from '../../../common/error';
+import { adminAllActiveUsers } from '../../client/http/admin';
+import { User } from '../../client/http/data';
+import useHandleError from '../../common/error';
 
 /**
  * It handles the addition of attendances. As it has to fetch all the users,

--- a/ui/src/admin/SessionDetail/AdminSessionDetail.tsx
+++ b/ui/src/admin/SessionDetail/AdminSessionDetail.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Container, Box, Button, CircularProgress, Paper, Typography } from '@mui/material';
-import { adminCreateSessionForm, adminDeleteSession, adminGetSession } from '../../../client/http/admin';
-import { AdminSession, SessionAttendanceAppliedBy } from '../../../client/http/data';
-import useHandleError from '../../../common/error';
-import { useHeader } from '../../../contexts/header';
-import SessionInfo from '../common/SessionInfo';
+import { adminCreateSessionForm, adminDeleteSession, adminGetSession } from '../../client/http/admin';
+import { AdminSession, SessionAttendanceAppliedBy } from '../../client/http/data';
+import useHandleError from '../../common/error';
+import { useHeader } from '../../contexts/header';
 import AttendanceQrPanel from './AttendanceQrPanel';
 import SessionAttendanceTable from './AttendanceTable';
+import SessionInfo from './SessionInfo';
 
 const AdminSessionDetail = () => {
   useHeader({ newTitle: 'Session Detail' });

--- a/ui/src/admin/SessionDetail/AttendanceQrPanel.tsx
+++ b/ui/src/admin/SessionDetail/AttendanceQrPanel.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, CircularProgress, Grid, Paper, Typography } from '@mui/material';
 import { QRCodeCanvas } from 'qrcode.react';
-import { AdminSession } from '../../../client/http/data';
-import { formatDateToMonthDate } from '../../../common/date';
+import { AdminSession } from '../../client/http/data';
+import { formatDateToMonthDate } from '../../common/date';
 
 const AttendanceQrPanel = ({
   session,

--- a/ui/src/admin/SessionDetail/AttendanceTable.tsx
+++ b/ui/src/admin/SessionDetail/AttendanceTable.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Typography, Paper, Box, CircularProgress, Tabs, Tab } from '@mui/material';
-import { useAuth } from '../../../auth';
-import { adminMarkUsersAsPresent } from '../../../client/http/admin';
-import { Attendance } from '../../../client/http/data';
-import { getSessionAttendances } from '../../../client/http/default';
-import useHandleError from '../../../common/error';
-import UserAttendance from '../common/UserAttendance';
+import { useAuth } from '../../auth';
+import { adminMarkUsersAsPresent } from '../../client/http/admin';
+import { Attendance } from '../../client/http/data';
+import { getSessionAttendances } from '../../client/http/default';
+import useHandleError from '../../common/error';
 import AddAttendance from './AddAttendance';
+import UserAttendance from './UserAttendance';
 
 type TabTypes = 'attendance' | 'addAttendance';
 

--- a/ui/src/admin/SessionDetail/SessionInfo.tsx
+++ b/ui/src/admin/SessionDetail/SessionInfo.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { CalendarTodayOutlined, StarBorderRounded } from '@mui/icons-material';
 import { TextField, Typography, Paper, Stack, Box, Grid } from '@mui/material';
 import { TimeIcon } from '@mui/x-date-pickers';
-import { Session } from '../../../client/http/data';
-import { toYYslashMMslashDDspaceHHcolonMM, toYYYY년MM월DD일HH시MM분 } from '../../../common/date';
+import { Session } from '../../client/http/data';
+import { toYYslashMMslashDDspaceHHcolonMM, toYYYY년MM월DD일HH시MM분 } from '../../common/date';
 
 type EditableSessionData = {
   name: string;

--- a/ui/src/admin/SessionDetail/UserAttendance.tsx
+++ b/ui/src/admin/SessionDetail/UserAttendance.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
 import { CircularProgress, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Box } from '@mui/material';
-import { Attendance } from '../../../client/http/data';
-import { toYYslashMMslashDDspaceHHcolonMMcolonSS } from '../../../common/date';
+import { Attendance } from '../../client/http/data';
+import { toYYslashMMslashDDspaceHHcolonMMcolonSS } from '../../common/date';
 
 type OrderBy = 'asc' | 'desc';
 

--- a/ui/src/admin/SessionDetail/index.ts
+++ b/ui/src/admin/SessionDetail/index.ts
@@ -1,4 +1,3 @@
 import AdminSessionDetail from './AdminSessionDetail';
 
-// TODO(#57): Move this to src/admin directory.
 export default AdminSessionDetail;

--- a/ui/src/admin/SessionList.tsx
+++ b/ui/src/admin/SessionList.tsx
@@ -18,11 +18,11 @@ import {
   LinearProgress,
   Typography,
 } from '@mui/material';
-import SessionCreate from '../../SessionCreate';
-import { adminListSessions } from '../../client/http/admin';
-import { AdminSession } from '../../client/http/data';
-import { toYYslashMMslashDDspaceHHcolonMMwithDay } from '../../common/date';
-import { useHeader } from '../../contexts/header';
+import SessionCreate from '../SessionCreate';
+import { adminListSessions } from '../client/http/admin';
+import { AdminSession } from '../client/http/data';
+import { toYYslashMMslashDDspaceHHcolonMMwithDay } from '../common/date';
+import { useHeader } from '../contexts/header';
 
 const AdminSessionList = () => {
   const navigate = useNavigate();

--- a/ui/src/user/SessionDetail/AttendanceTable.tsx
+++ b/ui/src/user/SessionDetail/AttendanceTable.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
 import { Typography, Paper, Box, CircularProgress } from '@mui/material';
-import { useAuth } from '../../../auth';
-import { Attendance } from '../../../client/http/data';
-import { getSessionAttendances } from '../../../client/http/default';
-import useHandleError from '../../../common/error';
-import UserAttendance from '../common/UserAttendance';
+import { useAuth } from '../../auth';
+import { Attendance } from '../../client/http/data';
+import { getSessionAttendances } from '../../client/http/default';
+import useHandleError from '../../common/error';
+import UserAttendance from './UserAttendance';
 
 /**
  * The attendance table for the session. It handles the attendance data view and the add attendance action.

--- a/ui/src/user/SessionDetail/SessionInfo.tsx
+++ b/ui/src/user/SessionDetail/SessionInfo.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react';
+import { CalendarTodayOutlined, StarBorderRounded } from '@mui/icons-material';
+import { TextField, Typography, Paper, Stack, Box, Grid } from '@mui/material';
+import { TimeIcon } from '@mui/x-date-pickers';
+import { Session } from '../../client/http/data';
+import { toYYslashMMslashDDspaceHHcolonMM, toYYYY년MM월DD일HH시MM분 } from '../../common/date';
+
+type EditableSessionData = {
+  name: string;
+  description: string;
+  score: number;
+  startsAt: Date;
+};
+
+type InputNames = keyof EditableSessionData;
+
+const SessionInfo = ({ session }: { session: Session }) => {
+  const [isEditing] = useState(false);
+  const [sessionData, setSessionData] = useState<EditableSessionData>({
+    name: session.name,
+    description: session.description,
+    score: session.score,
+    startsAt: session.startsAt,
+  });
+  const [errors, setErrors] = useState({
+    name: false,
+    score: false,
+  });
+
+  const handleInputChange = (inputName: InputNames, newValue: string) => {
+    const prevData = sessionData;
+    const newData = {
+      ...prevData,
+      [inputName]: inputName === 'score' ? Number(newValue) : newValue,
+    };
+    setSessionData(newData);
+    validateFields(newData);
+  };
+
+  const validateFields = (newData: EditableSessionData) => {
+    let isValid = true;
+    const newErrors = { name: false, score: false };
+
+    if (!newData.name) {
+      newErrors.name = true;
+      isValid = false;
+    }
+
+    if (newData.score <= 0) {
+      newErrors.score = true;
+      isValid = false;
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  return (
+    <Paper sx={{ p: 2 }} elevation={4}>
+      <Stack spacing={2}>
+        {isEditing ? (
+          <>
+            <TextField
+              label="Session Name"
+              value={sessionData.name}
+              onChange={(e) => handleInputChange('name', e.target.value)}
+              variant="outlined"
+              required
+              fullWidth
+              error={errors.name}
+              helperText={errors.name ? 'Session name is required' : ''}
+            />
+            <TextField
+              label="Description"
+              value={sessionData.description || ''}
+              onChange={(e) => handleInputChange('description', e.target.value)}
+              multiline
+              rows={3}
+              variant="outlined"
+              fullWidth
+            />
+            <TextField
+              label="Starts At"
+              type="datetime-local"
+              value={sessionData.startsAt}
+              onChange={(e) => handleInputChange('startsAt', e.target.value)}
+              variant="outlined"
+              required
+              fullWidth
+            />
+            <TextField
+              label="Score"
+              type="number"
+              value={sessionData.score}
+              onChange={(e) => handleInputChange('score', e.target.value)}
+              variant="outlined"
+              inputProps={{ min: 0 }}
+              required
+              fullWidth
+              error={errors.score}
+              helperText={errors.score ? 'Score must be greater than 0' : ''}
+            />
+          </>
+        ) : (
+          <>
+            <Typography variant="h6">{session.name}</Typography>
+            <Paper sx={{ p: 1 }} variant="outlined">
+              <Typography variant="body2" color={session.description ? 'initial' : 'text.secondary'}>
+                {session.description ? session.description : 'No description'}
+              </Typography>
+            </Paper>
+            <Grid container spacing={2}>
+              <Grid item xs={12} sm={6}>
+                <Box display="flex" alignItems="center">
+                  <CalendarTodayOutlined sx={{ mr: 1 }} color="primary" />
+                  <Typography variant="body2">시작 시간: {toYYYY년MM월DD일HH시MM분(session.startsAt)}</Typography>
+                </Box>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <Box display="flex" alignItems="center">
+                  <StarBorderRounded sx={{ mr: 1 }} color="primary" />
+                  <Typography variant="body2">출석 점수: {session.score}점</Typography>
+                </Box>
+              </Grid>
+            </Grid>
+          </>
+        )}
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Box display="flex" gap={1} alignItems="center" justifyContent="center">
+            <TimeIcon color="action" style={{ width: 16, height: 16 }} />
+            <Typography variant="body2" color="text.secondary">
+              Created at {toYYslashMMslashDDspaceHHcolonMM(session.createdAt)}
+            </Typography>
+          </Box>
+          {/* TODO(#188): Add the button to toggle. */}
+        </Box>
+      </Stack>
+    </Paper>
+  );
+};
+
+export default SessionInfo;

--- a/ui/src/user/SessionDetail/UserAttendance.tsx
+++ b/ui/src/user/SessionDetail/UserAttendance.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { ArrowDownward, ArrowUpward } from '@mui/icons-material';
+import { CircularProgress, TableContainer, Table, TableHead, TableRow, TableCell, TableBody, Box } from '@mui/material';
+import { Attendance } from '../../client/http/data';
+import { toYYslashMMslashDDspaceHHcolonMMcolonSS } from '../../common/date';
+
+type OrderBy = 'asc' | 'desc';
+
+type OrderKeys = 'userExternalName' | 'userGeneration' | 'userJoinedAt';
+
+const UserAttendance = ({ attendances, isLoading }: { attendances: Attendance[]; isLoading: boolean }) => {
+  const [nameOrder, setNameOrder] = useState<OrderBy>('asc');
+  const [generationOrder, setGenerationOrder] = useState<OrderBy>('asc');
+  const [joinedAtOrder, setJoinedAtOrder] = useState<OrderBy>('asc');
+  const [orderBy, setOrderBy] = useState<OrderKeys>('userExternalName');
+
+  const onSortChange = (newOrderBy: OrderKeys) => {
+    switch (newOrderBy) {
+      case 'userExternalName':
+        setNameOrder(oppositeOrder(nameOrder));
+        setOrderBy(newOrderBy);
+        break;
+      case 'userGeneration':
+        setGenerationOrder(oppositeOrder(generationOrder));
+        setOrderBy(newOrderBy);
+        break;
+      case 'userJoinedAt':
+        setJoinedAtOrder(oppositeOrder(joinedAtOrder));
+        setOrderBy(newOrderBy);
+        break;
+      default:
+        break;
+    }
+  };
+
+  const oppositeOrder = (order: OrderBy) => (order === 'asc' ? 'desc' : 'asc');
+
+  const sortedAttendances = attendances.slice().sort((a, b) => {
+    switch (orderBy) {
+      case 'userExternalName':
+        return (a.userExternalName < b.userExternalName ? -1 : 1) * (nameOrder === 'asc' ? 1 : -1);
+      case 'userGeneration':
+        return (a.userGeneration < b.userGeneration ? -1 : 1) * (generationOrder === 'asc' ? 1 : -1);
+      case 'userJoinedAt':
+        return (a.userJoinedAt < b.userJoinedAt ? -1 : 1) * (joinedAtOrder === 'asc' ? 1 : -1);
+      default:
+        return 0;
+    }
+  });
+
+  if (isLoading) {
+    return <CircularProgress />;
+  }
+
+  return (
+    <TableContainer sx={{ overflowY: 'auto', maxHeight: 400 }}>
+      <Table>
+        <TableHead sx={{ position: 'sticky', top: 0, backgroundColor: 'background.paper' }}>
+          <TableRow>
+            <TableCell align="center" sx={{ width: '30%' }} onClick={() => onSortChange('userExternalName')}>
+              <Box display="flex" alignItems="center" gap={1} fontSize={{ xs: '12px', sm: '14px', md: '16px' }}>
+                이름
+                <OrderArrows
+                  active={orderBy === 'userExternalName'}
+                  order={nameOrder}
+                  onClick={() => onSortChange('userExternalName')}
+                />
+              </Box>
+            </TableCell>
+            <TableCell align="center" sx={{ width: '30%' }} onClick={() => onSortChange('userGeneration')}>
+              <Box display="flex" alignItems="center" gap={1} fontSize={{ xs: '12px', sm: '14px', md: '16px' }}>
+                기수
+                <OrderArrows
+                  active={orderBy === 'userGeneration'}
+                  order={generationOrder}
+                  onClick={() => onSortChange('userGeneration')}
+                />
+              </Box>
+            </TableCell>
+            <TableCell align="center" sx={{ width: '40%' }} onClick={() => onSortChange('userJoinedAt')}>
+              <Box display="flex" alignItems="center" gap={1} fontSize={{ xs: '12px', sm: '14px', md: '16px' }}>
+                제출 시간
+                <OrderArrows
+                  active={orderBy === 'userJoinedAt'}
+                  order={joinedAtOrder}
+                  onClick={() => onSortChange('userJoinedAt')}
+                />
+              </Box>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sortedAttendances.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={3}>출석 제출 목록이 없습니다.</TableCell>
+            </TableRow>
+          ) : (
+            sortedAttendances.map((attendance) => (
+              <TableRow key={attendance.id}>
+                <TableCell align="center" sx={{ width: '30%' }}>
+                  {attendance.userExternalName}
+                </TableCell>
+                <TableCell align="center" sx={{ width: '30%' }}>
+                  {attendance.userGeneration}
+                </TableCell>
+                <TableCell align="center" sx={{ width: '40%' }}>
+                  {toYYslashMMslashDDspaceHHcolonMMcolonSS(attendance.userJoinedAt)}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+const OrderArrows = ({ active, order, onClick }: { active: boolean; order: OrderBy; onClick: () => void }) => (
+  <Box display="flex" alignItems="center" onClick={onClick}>
+    {order === 'asc' ? (
+      <ArrowUpward color={active ? 'primary' : 'action'} sx={{ width: 16, height: 16, p: 0 }} />
+    ) : (
+      <ArrowDownward color={active ? 'primary' : 'action'} sx={{ width: 16, height: 16, p: 0 }} />
+    )}
+  </Box>
+);
+
+export default UserAttendance;

--- a/ui/src/user/SessionDetail/UserSessionDetail.tsx
+++ b/ui/src/user/SessionDetail/UserSessionDetail.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { Container, Box, Button, CircularProgress } from '@mui/material';
-import { Session } from '../../../client/http/data';
-import { getSession } from '../../../client/http/default';
-import useHandleError from '../../../common/error';
-import { useHeader } from '../../../contexts/header';
-import SessionInfo from '../common/SessionInfo';
+import { Session } from '../../client/http/data';
+import { getSession } from '../../client/http/default';
+import useHandleError from '../../common/error';
+import { useHeader } from '../../contexts/header';
 import SessionAttendanceTable from './AttendanceTable';
+import SessionInfo from './SessionInfo';
 
 const UserSessionDetail = () => {
   useHeader({ newTitle: 'Session Detail' });

--- a/ui/src/user/SessionDetail/index.ts
+++ b/ui/src/user/SessionDetail/index.ts
@@ -1,4 +1,3 @@
-import AdminSessionDetail from './admin';
-import UserSessionDetail from './user';
+import UserSessionDetail from './UserSessionDetail';
 
-export { AdminSessionDetail, UserSessionDetail };
+export default UserSessionDetail;

--- a/ui/src/user/SessionDetail/user/index.ts
+++ b/ui/src/user/SessionDetail/user/index.ts
@@ -1,3 +1,0 @@
-import UserSessionDetail from './UserSessionDetail';
-
-export default UserSessionDetail;

--- a/ui/src/user/SessionList.tsx
+++ b/ui/src/user/SessionList.tsx
@@ -14,16 +14,14 @@ import {
   TablePagination,
 } from '@mui/material';
 import dayjs from 'dayjs';
-import { Session } from '../../client/http/data';
-import { listSessions } from '../../client/http/default';
-import { toYYYY년MM월DD일HH시MM분 } from '../../common/date';
-import useHandleError from '../../common/error';
-import { useHeader } from '../../contexts/header';
-import { useAdminMode } from '../../mode';
+import { Session } from '../client/http/data';
+import { listSessions } from '../client/http/default';
+import { toYYYY년MM월DD일HH시MM분 } from '../common/date';
+import useHandleError from '../common/error';
+import { useHeader } from '../contexts/header';
 
-const UserSessionList = () => {
+const SessionList = () => {
   const navigate = useNavigate();
-  const { adminMode } = useAdminMode();
   const { handleError } = useHandleError();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -35,11 +33,6 @@ const UserSessionList = () => {
   const [currentPage, setCurrentPage] = useState(0);
   const [isEnd, setIsEnd] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-
-  // TODO(#209): Split user/admin UIs and routes all together.
-  if (adminMode) {
-    navigate('/admin/sessions');
-  }
 
   const fetchSessions = useCallback(
     async (page: number) => {
@@ -152,4 +145,4 @@ const SessionCard = ({ session, onClick }: { session: Session; onClick: () => vo
   );
 };
 
-export default UserSessionList;
+export default SessionList;

--- a/ui/src/user/SessionList/index.ts
+++ b/ui/src/user/SessionList/index.ts
@@ -1,4 +1,0 @@
-import AdminSessionList from './AdminSessionList';
-import UserSessionList from './UserSessionList';
-
-export { UserSessionList, AdminSessionList };


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->

- Issue: #57 #209 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Split `AdminSessionDetail` and its sub-components and move them to `src/admin`.
- Update routing in Routes.tsx to include new admin and user session components.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
