### PR TITLE
[#57] Add force apply option for attendance marking and implement late apply endpoint

### DIFF
--- a/attendance/repo.go
+++ b/attendance/repo.go
@@ -38,6 +38,8 @@ type mongodbAttendance struct {
 	// The user or service that created the attendance record.
 	// E.g. "auto-syncer", "user-id-123"
 	CreatedBy string `bson:"created_by"`
+	// Whether the attendance record was force applied.
+	ForceApply bool `bson:"force_apply"`
 }
 
 type mongodbRepo struct {
@@ -121,6 +123,7 @@ type AddAttendanceReq struct {
 	UserGeneration   float64
 	UserJoinedAt     time.Time
 	CreatedBy        string
+	ForceApply       bool
 }
 
 func (m *mongodbRepo) BulkInsert(requests []AddAttendanceReq) error {
@@ -143,6 +146,7 @@ func (m *mongodbRepo) BulkInsert(requests []AddAttendanceReq) error {
 			UserJoinedAt:     request.UserJoinedAt,
 			CreatedAt:        now,
 			CreatedBy:        request.CreatedBy,
+			ForceApply:       request.ForceApply,
 		})
 	}
 

--- a/http/router.go
+++ b/http/router.go
@@ -46,6 +46,7 @@ func SetUpRouter(router *gin.Engine, server *server.Server) {
 				adminProtected.POST("/sessions/:id/attendance-form", handleCreateAttendanceForm(server))
 				adminProtected.POST("/sessions/:id/attendance/form", handleApplyAttendanceByFormSubmissions(server))
 				adminProtected.POST("/sessions/:id/attendance/manual", handleMarkUsersAsPresent(server))
+				adminProtected.POST("/sessions/:id/attendance/late", handleLateApplyAttendance(server))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- PR title foramt should be `[#xxx] Describe what has been done in the PR` where xxx is the related issue number. -->
<!-- ex) [#1] Add GitHub pull request template -->

## Background <!-- Required -->

<!-- Attach the issue or task, brifely explain the background, current state or any necessary information to understand the issue and PR. -->

- Issue: #57 

<!-- If this PR resolves any issues, please mention them. -->
<!-- E.g., Resolves #000 -->

## Changes <!-- Required -->

<!-- Describe what changes or additions have been made in this PR. -->
<!-- If there are any UI changes, please include screenshots to demonstrate them. -->

- Introduced `ForceApply` field in attendance records to allow attendance to be marked regardless of session status.
- Updated `MarkUsersAsPresent` method to accept a `forceApply` boolean parameter.
- Added new endpoint for late applying attendance, enabling users to be marked present even after the session has closed.
- Updated related tests to cover new functionality and ensure proper behavior with the force apply option.

## Considerations <!-- Optional -->

<!-- List any points that can not be described through code, -->
<!-- or the reason why a certain way has been chosen among other ways -->
<!-- Include them only when they are necessary, and not obvious. -->
<!-- Do not abuse this section. Represent through the code as much as possible. -->

## Remaining Tasks <!-- Optional -->

<!-- Tasks to be completed after this PR. -->
